### PR TITLE
new channel id format

### DIFF
--- a/Discord Data Package Parser/MainWindow.xaml.cs
+++ b/Discord Data Package Parser/MainWindow.xaml.cs
@@ -180,7 +180,7 @@ namespace Discord_Data_Package_Parser
         //##########----Message Loader----##########
         private void LoadMessages(string ID)
         {
-            string messageDIR = dataDIR + "/messages/" + ID;
+            string messageDIR = dataDIR + "/messages/c" + ID;
             if (File.Exists(messageDIR + "/messages.csv"))
             {
                 using (var reader = new StreamReader(messageDIR + "/messages.csv"))


### PR DESCRIPTION
discord changed channel ids in data packages, adding a c before the id allows message.csv files to be read again